### PR TITLE
Align Bedrock setup guidance across authorization samples

### DIFF
--- a/asynchronous-authorization/langchain-next-js/README.md
+++ b/asynchronous-authorization/langchain-next-js/README.md
@@ -40,8 +40,8 @@ AIエージェントは間違いを犯したり、ユーザーの意図を誤解
 ### 1. リポジトリのクローン
 
 ```bash
-git clone https://github.com/auth0-samples/auth0-assistant0.git
-cd auth0-assistant0/asynchronous-authorization/langchain-next-js
+git clone https://github.com/auth0-samples/auth0-ai-samples.git
+cd auth0-ai-samples/asynchronous-authorization/langchain-next-js
 ```
 
 ### 2. 環境変数の設定
@@ -63,6 +63,9 @@ BEDROCK_CHAT_MODEL_ID="anthropic.claude-3-5-sonnet-20241022-v1:0"
 BEDROCK_EMBEDDING_MODEL_ID="amazon.titan-embed-text-v2:0"
 ```
 
+- Bearer Token の取得手順と IAM ポリシーの例は [docs/aws-bedrock-setup.md](../../docs/aws-bedrock-setup.md) を参照してください
+- `ChatBedrockConverse` を利用するため、モデル ID にはバージョン（`:0` など）が必要です
+
 #### Auth0設定
 
 ```bash
@@ -72,6 +75,10 @@ AUTH0_DOMAIN="https://YOUR_DOMAIN.auth0.com"
 AUTH0_CLIENT_ID="<your-client-id>"
 AUTH0_CLIENT_SECRET="<your-client-secret>"
 ```
+
+- [Auth0 Dashboard](https://manage.auth0.com/) で Regular Web Application を作成
+- Allowed Callback URLs: `http://localhost:3000/api/auth/callback`
+- Allowed Logout URLs / Allowed Web Origins: `http://localhost:3000`
 
 **Auth0セットアップ手順:**
 1. [Auth0ダッシュボード](https://manage.auth0.com/)にアクセス

--- a/asynchronous-authorization/langchain-next-js/README_ja.md
+++ b/asynchronous-authorization/langchain-next-js/README_ja.md
@@ -15,8 +15,8 @@ Assistant0は、複数のツールに動的にアクセスすることで、あ�
 ### 1. リポジトリのクローン
 
 ```bash
-git clone https://github.com/auth0-samples/auth0-assistant0.git
-cd auth0-assistant0/asynchronous-authorization/langchain-next-js
+git clone https://github.com/auth0-samples/auth0-ai-samples.git
+cd auth0-ai-samples/asynchronous-authorization/langchain-next-js
 ```
 
 ### 2. 環境変数の設定
@@ -27,14 +27,33 @@ cd auth0-assistant0/asynchronous-authorization/langchain-next-js
 cp .env.example .env.local
 ```
 
-### 3. 必要な設定の取得
+`.env.local` に以下の値を設定します。
 
-基本的な例を始めるには、Amazon Bedrock設定（リージョン、チャットモデルID、埋め込みモデルID）とAuth0認証情報を追加します。
+#### Amazon Bedrock（Bearer Token 認証）
 
-- 選択したリージョンでAmazon Bedrockを呼び出す権限を持つAWS認証情報が必要です
-- WebアプリとMachine to Machine AppのAuth0認証情報が必要です
-  - [Prerequisites手順](https://auth0.com/ai/docs/call-others-apis-on-users-behalf)に従って、Auth0 WebアプリとToken Vaultを設定できます
-  - [Auth0 FGAアカウント](https://dashboard.fga.dev)を作成し、FGAストアID、クライアントID、クライアントシークレット、API URLを`.env.local`ファイルに追加します
+```bash
+AWS_BEARER_TOKEN_BEDROCK="<your-bedrock-bearer-token>"
+BEDROCK_REGION="us-east-1"
+BEDROCK_CHAT_MODEL_ID="anthropic.claude-3-5-sonnet-20241022-v1:0"
+BEDROCK_EMBEDDING_MODEL_ID="amazon.titan-embed-text-v2:0"
+```
+
+- Bearer Token の取得方法と IAM ポリシーの詳細は [docs/aws-bedrock-setup.md](../../docs/aws-bedrock-setup.md) を参照してください
+- `ChatBedrockConverse` を利用するため、モデル ID にはバージョン（`:0` など）が必要です
+
+#### Auth0
+
+```bash
+APP_BASE_URL="http://localhost:3000"
+AUTH0_SECRET="<32文字以上のランダムな文字列>"
+AUTH0_DOMAIN="https://<your-tenant>.auth0.com"
+AUTH0_CLIENT_ID="<your-client-id>"
+AUTH0_CLIENT_SECRET="<your-client-secret>"
+```
+
+- [Auth0 Dashboard](https://manage.auth0.com/) で Regular Web Application を作成します
+- Allowed Callback URLs: `http://localhost:3000/api/auth/callback`
+- Allowed Logout URLs / Allowed Web Origins: `http://localhost:3000`
 
 ### 4. パッケージのインストールとデータベース初期化
 
@@ -114,8 +133,8 @@ Auth0の[Token Vault](https://auth0.com/docs/secure/tokens/token-vault)機能は
 
 Vercelの無料枠にも対応しています！
 
-[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/oktadev/auth0-assistant0)
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Foktadev%2Fauth0-assistant0)
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/auth0-samples/auth0-ai-samples)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fauth0-samples%2Fauth0-ai-samples)
 
 ## 📦 バンドルサイズ
 

--- a/asynchronous-authorization/langchain-next-js/package.json
+++ b/asynchronous-authorization/langchain-next-js/package.json
@@ -27,10 +27,10 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@auth0/ai-langchain": "3",
+    "@auth0/ai-langchain": "3.2.0",
     "@auth0/nextjs-auth0": "4.4.2",
     "@langchain/community": "0.3.42",
-    "@langchain/core": "0.3",
+    "@langchain/core": "0.3.63",
     "@langchain/langgraph": "^0.4.4",
     "@langchain/aws": "^0.1.15",
     "@radix-ui/react-avatar": "^1.1.7",
@@ -47,8 +47,8 @@
     "drizzle-orm": "^0.43.1",
     "drizzle-zod": "^0.7.1",
     "googleapis": "^148.0.0",
-    "langchain": "0.3",
-    "langgraph-nextjs-api-passthrough": "0.1",
+    "langchain": "0.3.30",
+    "langgraph-nextjs-api-passthrough": "0.1.3",
     "lucide-react": "^0.475.0",
     "marked": "^15.0.7",
     "nanoid": "^5.1.5",

--- a/authorization-for-rag/langchain-next-js/README.md
+++ b/authorization-for-rag/langchain-next-js/README.md
@@ -39,8 +39,8 @@
 ### 1. リポジトリのクローン
 
 ```bash
-git clone https://github.com/auth0-samples/auth0-assistant0.git
-cd auth0-assistant0/authorization-for-rag/langchain-next-js
+git clone https://github.com/auth0-samples/auth0-ai-samples.git
+cd auth0-ai-samples/authorization-for-rag/langchain-next-js
 ```
 
 ### 2. 環境変数の設定
@@ -62,6 +62,9 @@ BEDROCK_CHAT_MODEL_ID="anthropic.claude-3-5-sonnet-20241022-v1:0"
 BEDROCK_EMBEDDING_MODEL_ID="amazon.titan-embed-text-v2:0"
 ```
 
+- Bearer Token の取得手順と必要な IAM ポリシーは [docs/aws-bedrock-setup.md](../../docs/aws-bedrock-setup.md) を参照してください
+- `ChatBedrockConverse` を利用するため、モデル ID にはバージョン（`:0` など）が必要です
+
 #### Auth0設定
 
 ```bash
@@ -71,6 +74,10 @@ AUTH0_DOMAIN="https://YOUR_DOMAIN.auth0.com"
 AUTH0_CLIENT_ID="<your-client-id>"
 AUTH0_CLIENT_SECRET="<your-client-secret>"
 ```
+
+- [Auth0 Dashboard](https://manage.auth0.com/) で Regular Web Application を作成
+- Allowed Callback URLs: `http://localhost:3000/api/auth/callback`
+- Allowed Logout URLs / Allowed Web Origins: `http://localhost:3000`
 
 #### Auth0 FGA設定
 

--- a/authorization-for-rag/langchain-next-js/README_ja.md
+++ b/authorization-for-rag/langchain-next-js/README_ja.md
@@ -15,8 +15,8 @@ Assistant0は、複数のツールに動的にアクセスすることで、あ�
 ### 1. リポジトリのクローン
 
 ```bash
-git clone https://github.com/auth0-samples/auth0-assistant0.git
-cd auth0-assistant0/authorization-for-rag/langchain-next-js
+git clone https://github.com/auth0-samples/auth0-ai-samples.git
+cd auth0-ai-samples/authorization-for-rag/langchain-next-js
 ```
 
 ### 2. 環境変数の設定
@@ -27,14 +27,58 @@ cd auth0-assistant0/authorization-for-rag/langchain-next-js
 cp .env.example .env.local
 ```
 
-### 3. 必要な設定の取得
+`.env.local` に以下の値を設定します。
 
-基本的な例を始めるには、Amazon Bedrock設定（リージョン、チャットモデルID、埋め込みモデルID）とAuth0認証情報を追加します。
+#### Amazon Bedrock（Bearer Token 認証）
 
-- 選択したリージョンでAmazon Bedrockを呼び出す権限を持つAWS認証情報が必要です
-- WebアプリとMachine to Machine AppのAuth0認証情報が必要です
-  - [Prerequisites手順](https://auth0.com/ai/docs/call-others-apis-on-users-behalf)に従って、Auth0 WebアプリとToken Vaultを設定できます
-  - [Auth0 FGAアカウント](https://dashboard.fga.dev)を作成し、FGAストアID、クライアントID、クライアントシークレット、API URLを`.env.local`ファイルに追加します
+```bash
+AWS_BEARER_TOKEN_BEDROCK="<your-bedrock-bearer-token>"
+BEDROCK_REGION="us-east-1"
+BEDROCK_CHAT_MODEL_ID="anthropic.claude-3-5-sonnet-20241022-v1:0"
+BEDROCK_EMBEDDING_MODEL_ID="amazon.titan-embed-text-v2:0"
+```
+
+- Bearer Token の取得手順と必要な IAM ポリシーは [docs/aws-bedrock-setup.md](../../docs/aws-bedrock-setup.md) を参照してください
+- `ChatBedrockConverse` を利用するため、モデル ID にはバージョン（`:0` など）が必要です
+
+#### Auth0
+
+```bash
+APP_BASE_URL="http://localhost:3000"
+AUTH0_SECRET="<32文字以上のランダムな文字列>"
+AUTH0_DOMAIN="https://<your-tenant>.auth0.com"
+AUTH0_CLIENT_ID="<your-client-id>"
+AUTH0_CLIENT_SECRET="<your-client-secret>"
+```
+
+- [Auth0 Dashboard](https://manage.auth0.com/) で Regular Web Application を作成します
+- Allowed Callback URLs: `http://localhost:3000/api/auth/callback`
+- Allowed Logout URLs / Allowed Web Origins: `http://localhost:3000`
+
+#### Auth0 FGA
+
+```bash
+FGA_STORE_ID="<your-fga-store-id>"
+FGA_CLIENT_ID="<your-fga-client-id>"
+FGA_CLIENT_SECRET="<your-fga-client-secret>"
+FGA_API_URL="https://api.us1.fga.dev"
+```
+
+- [dashboard.fga.dev](https://dashboard.fga.dev) で Store を作成し、クレデンシャルを取得します
+- `npm run fga:init` で初期モデルをデプロイできます
+
+#### データベース
+
+```bash
+DATABASE_URL="postgresql://postgres:postgres@localhost:5432/ai_documents_db"
+```
+
+#### LangGraph
+
+```bash
+LANGGRAPH_API_URL="http://localhost:54367"
+LANGCHAIN_CALLBACKS_BACKGROUND=false
+```
 
 ### 4. パッケージのインストールとデータベース初期化
 
@@ -105,8 +149,8 @@ Auth0の[Token Vault](https://auth0.com/docs/secure/tokens/token-vault)機能は
 
 Vercelの無料枠にも対応しています！
 
-[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/oktadev/auth0-assistant0)
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Foktadev%2Fauth0-assistant0)
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/auth0-samples/auth0-ai-samples)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fauth0-samples%2Fauth0-ai-samples)
 
 ## 📦 バンドルサイズ
 

--- a/authorization-for-rag/langchain-next-js/package.json
+++ b/authorization-for-rag/langchain-next-js/package.json
@@ -27,10 +27,10 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@auth0/ai-langchain": "3",
+    "@auth0/ai-langchain": "3.2.0",
     "@auth0/nextjs-auth0": "4.4.2",
     "@langchain/community": "0.3.42",
-    "@langchain/core": "0.3",
+    "@langchain/core": "0.3.63",
     "@langchain/langgraph": "^0.4.4",
     "@langchain/aws": "^0.1.15",
     "@radix-ui/react-avatar": "^1.1.7",
@@ -47,8 +47,8 @@
     "drizzle-orm": "^0.43.1",
     "drizzle-zod": "^0.7.1",
     "googleapis": "^148.0.0",
-    "langchain": "0.3",
-    "langgraph-nextjs-api-passthrough": "0.1",
+    "langchain": "0.3.30",
+    "langgraph-nextjs-api-passthrough": "0.1.3",
     "lucide-react": "^0.475.0",
     "marked": "^15.0.7",
     "nanoid": "^5.1.5",


### PR DESCRIPTION
## Summary
- align LangChain/LangGraph dependency versions in the authorization samples with the authenticate-users baseline
- refresh Japanese and default READMEs to point to the auth0-ai-samples repo and document Bedrock bearer token setup
- update quick-start links (Codespaces/Vercel) to the new repository

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e29632d8788326880e94d8b55e36d2